### PR TITLE
feature: ajout de la rétrocompatibilité avec phpunit >=5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.0",
         "elvanto/litemoji": "^1.1",
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^5.7||^6.0",
         "roave/security-advisories": "dev-master"
     },
     "require-dev": {

--- a/src/EmojiPrinter.php
+++ b/src/EmojiPrinter.php
@@ -8,6 +8,13 @@ use PHPUnit\Framework\TestSuite;
 use PHPUnit\TextUI\ResultPrinter;
 use PHPUnit\Util\Xml;
 
+// Backward compatibility with phpunit 5
+if (!class_exists('PHPUnit\TextUI\ResultPrinter')) {
+    class_alias(\PHPUnit_TextUI_ResultPrinter::class, 'PHPUnit\TextUI\ResultPrinter');
+    class_alias(\PHPUnit_Framework_TestSuite::class, 'PHPUnit\Framework\TestSuite');
+    class_alias(\PHPUnit_Util_XML::class, 'PHPUnit\Util\XML');
+}
+
 final class EmojiPrinter extends ResultPrinter
 {
     const CONFIG = __DIR__ . '/../config';


### PR DESCRIPTION
Description
--------
feature: ajout de la rétrocompatibilité avec phpunit >=5.7

Implémentation
-----------
Ajout de class alias pour que les nom de classe de phpunit 6 soit reconnu.

Test
------------
1. Tester sous PHPUNIT 5.7
:+1: OK 
2. Tester sous PHPUNIT 6 
:+1: OK 

Dépendances
------------------
Aucune