### PR TITLE
Ease Install: removing dep on roave/security-advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
     "require": {
         "php": "^7.0",
         "elvanto/litemoji": "^1.1",
-        "phpunit/phpunit": "^6.0",
-        "roave/security-advisories": "dev-master"
+        "phpunit/phpunit": "^6.0"
     },
     "require-dev": {
         "pds/skeleton": "1.*",


### PR DESCRIPTION
Hey @coderabbi!

This dependency makes the lib a bit hard to install, since the `dev-master` of the lib will conflict with normal minimum-stability. And... I think it's not needed and is unrelated. Can we remove it?

Cheers!